### PR TITLE
Revise clarity blog post

### DIFF
--- a/_posts/2024-06-01-clarity-for-builders.md
+++ b/_posts/2024-06-01-clarity-for-builders.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title: "clarity wins for builders"
+tags:
+- Building
+- Clarity
+- Mindset
+---
+
+clarity lets builders move fast because everyone knows the job to be done. when the problem and the goal are crisp, decisions shrink to yes or no, and teams sprint instead of circling. meetings get shorter, handoffs are smoother, and the product gets better because there is one shared picture in everyone’s head.
+
+a clear mission also pulls people in. the tighter the statement, the easier it is for partners, teammates, and early users to line up behind it. i reread drafts until the promise feels obvious and memorable; if it isn’t, i rewrite until it is.
+
+clarity makes you durable when things go wrong. if fundraising slows or a feature slips, you adjust tactics without losing direction. the market can stay chaotic, but inside the team, the mission stays boringly consistent. that calm, steady focus is the edge. i reread this piece before publishing to be sure every line aims at that steadiness.


### PR DESCRIPTION
## Summary
- rewrite the clarity blog entry to remove the Modi example and emphasize self-editing for clarity

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e59968d04832eb747e982f80696bb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new blog post at `_posts/2024-06-01-clarity-for-builders.md` with front matter and content on clarity for builders.
> 
> - **Blog**:
>   - Add new post `/_posts/2024-06-01-clarity-for-builders.md` with `layout: post`, title, and tags (`Building`, `Clarity`, `Mindset`), plus content emphasizing clarity, a tight mission, and durability during setbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da1e59b7739b6c21842d3ff55be182c8cd28c40a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->