### PR TITLE
Add keyboard navigation to search dropdown

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -123,12 +123,31 @@
         var resultsBox = document.getElementById('search-results');
         var data;
 
+        var activeIndex = -1;
+
         function render(list) {
           if (!resultsBox) return;
+          activeIndex = -1;
           if (!list.length) { resultsBox.innerHTML = ''; return; }
           resultsBox.innerHTML = list.map(function (item) {
-            return '<li><a href="' + item.url + '">' + item.title + '</a></li>';
+            return '<li><a href="' + item.url + '" tabindex="-1">' + item.title + '</a></li>';
           }).join('');
+        }
+
+        function getItems() {
+          return resultsBox ? Array.prototype.slice.call(resultsBox.querySelectorAll('a')) : [];
+        }
+
+        function updateActive(index) {
+          var items = getItems();
+          items.forEach(function (link) { link.classList.remove('active'); });
+          if (!items.length) return;
+          if (index < 0) index = items.length - 1;
+          if (index >= items.length) index = 0;
+          activeIndex = index;
+          var activeItem = items[activeIndex];
+          activeItem.classList.add('active');
+          activeItem.scrollIntoView({ block: 'nearest' });
         }
 
         function search(query) {
@@ -154,10 +173,26 @@
           if (!data) return; // fetch may still be in-flight
           search(this.value);
         });
+
+        input.addEventListener('keydown', function (event) {
+          var items = getItems();
+          if (!items.length) return;
+          if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            updateActive(activeIndex + 1);
+          } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            updateActive(activeIndex - 1);
+          } else if (event.key === 'Enter' && activeIndex >= 0) {
+            event.preventDefault();
+            items[activeIndex].click();
+          }
+        });
         // Hide results when clicking outside
         document.addEventListener('click', function(e){
           if(!resultsBox.contains(e.target) && e.target !== input){
             resultsBox.innerHTML='';
+            activeIndex = -1;
           }
         });
       })();

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -401,12 +401,22 @@ body.dark-mode .search-box ul {
   color: inherit;
 }
 
+.search-box li a.active,
 .search-box li a:hover {
   background: rgba(0, 0, 0, 0.04);
 }
 
+.search-box li a.active {
+  font-weight: 600;
+}
+
 body.dark-mode .search-box li a:hover {
   background: rgba(255, 255, 255, 0.06);
+}
+
+body.dark-mode .search-box li a.active {
+  background: rgba(255, 255, 255, 0.08);
+  font-weight: 600;
 }
 
 .search-box li + li {


### PR DESCRIPTION
## Summary
- add keyboard navigation handling to the search dropdown
- highlight and scroll active search results while navigating
- add styles for active search results in light and dark modes

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e8d13b9f4832ea44c8c36520f997a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds arrow-key navigation with active highlighting and enter-to-open in the search dropdown, with corresponding light/dark styles.
> 
> - **Search dropdown (HTML/JS in `_layouts/default.html`)**:
>   - Add keyboard navigation: track `activeIndex`, cycle with ArrowUp/ArrowDown, `Enter` to open.
>   - Render results with `tabindex="-1"`; highlight and `scrollIntoView` active item.
>   - Reset active state on re-render and when clicking outside.
> - **Styles (`assets/css/theme.css`)**:
>   - Add `.search-box li a.active` styles (highlight + bold).
>   - Dark mode variants for active state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f51958db826b2474a220553854dd39bd773189d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->