### PR TITLE
Add post: some thoughts on a post agi world and economy

### DIFF
--- a/_posts/2026-02-25-post-agi-world-economy.md
+++ b/_posts/2026-02-25-post-agi-world-economy.md
@@ -1,0 +1,60 @@
+---
+layout: post
+title: "some thoughts on a post agi world and economy"
+tags:
+- agi
+- economy
+- labor
+- execution
+---
+
+the economy is mostly atoms + energy + instructions.
+
+atoms are what you want (house, a meal, a road, a phone). energy is what moves atoms. instructions are what tell energy how to move atoms.
+
+for the last ~200 years, instructions were scarce.
+
+coordination was hard. planning was expensive. management was a tax.
+
+so we built companies to bundle cognition + capital + labor.
+
+agi flips that.
+
+when intelligence becomes abundant, two things happen at once:
+
+1/ planning/coordination collapses in cost  
+schedule, route, negotiate, monitor, procure, forecast, train, qa — all become software.
+
+2/ physical reality stays stubborn  
+gravity, distance, tool constraints, safety, permits, supply chains, breakage, fraud, weather, and “someone has to show up” or “be responsible” don’t go away.
+
+so the bottleneck moves from “can we think of the plan?” to “can we reliably execute in the real world?”
+
+in an agi world, physical labor allocation becomes a giant real-time optimization problem:
+
+- what is the task (desired end-state)
+- where is it (location + access)
+- when does it need to happen (deadline + dependencies)
+- with what (tools, parts, permissions, energy)
+- who/what can do it (human, robot, fleet, contractor)
+- how do we know it’s done (verification)
+- what happens when it fails (fallback + accountability)
+
+today we approximate this with managers, contractors, call centers, marketplaces, and paperwork. it’s slow because the instruction layer is slow, and the management layer is often bureaucratic.
+
+with agi, the natural shape is a superintelligent labor os:
+
+- every job is a spec: goal + constraints + acceptance test
+- every worker/robot becomes an api: capabilities + availability + reliability score
+- every city becomes a graph: travel time, risk, rules, access
+- pricing becomes a scheduling signal: urgency, difficulty, scarcity
+- verification becomes the trust layer: sensors, photos, receipts, audits, reputation
+- failures become training data: real-world evals → better dispatch policies
+
+robots will eat the predictable middle.
+
+humans will concentrate in the edges: ambiguity, care, judgment, negotiation, supervision, taste.
+
+one of the durable advantages is a trust graph that makes strangers executable.
+
+agi makes cognition cheap. we will turn cheap cognition into reliable atoms moved on time.

--- a/_posts/2026-02-25-post-agi-world-economy.md
+++ b/_posts/2026-02-25-post-agi-world-economy.md
@@ -8,6 +8,8 @@ tags:
 - execution
 ---
 
+![post agi world economy abstract header](/assets/img/post-agi-economy-header.svg)
+
 the economy is mostly atoms + energy + instructions.
 
 atoms are what you want (house, a meal, a road, a phone). energy is what moves atoms. instructions are what tell energy how to move atoms.

--- a/assets/img/post-agi-economy-header.svg
+++ b/assets/img/post-agi-economy-header.svg
@@ -1,0 +1,68 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">post agi world economy abstract header</title>
+  <desc id="desc">abstract visualization of atoms, energy, and instructions flowing through a network</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1600" y2="900" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0a0f1e"/>
+      <stop offset="1" stop-color="#1b2f5b"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(960 430) rotate(90) scale(360 700)">
+      <stop stop-color="#8cd5ff" stop-opacity="0.38"/>
+      <stop offset="1" stop-color="#8cd5ff" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="beam" x1="240" y1="450" x2="1360" y2="450" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5eead4" stop-opacity="0"/>
+      <stop offset="0.5" stop-color="#5eead4" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#5eead4" stop-opacity="0"/>
+    </linearGradient>
+    <filter id="soft" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="18"/>
+    </filter>
+  </defs>
+
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <rect width="1600" height="900" fill="url(#glow)"/>
+
+  <g opacity="0.35" stroke="#9fb7ff" stroke-width="1.5">
+    <path d="M110 180H1490"/>
+    <path d="M110 315H1490"/>
+    <path d="M110 450H1490"/>
+    <path d="M110 585H1490"/>
+    <path d="M110 720H1490"/>
+    <path d="M260 95V805"/>
+    <path d="M530 95V805"/>
+    <path d="M800 95V805"/>
+    <path d="M1070 95V805"/>
+    <path d="M1340 95V805"/>
+  </g>
+
+  <rect x="240" y="436" width="1120" height="28" rx="14" fill="url(#beam)" filter="url(#soft)"/>
+
+  <g fill="#fde68a" opacity="0.95">
+    <circle cx="320" cy="450" r="16"/>
+    <circle cx="560" cy="450" r="13"/>
+    <circle cx="800" cy="450" r="11"/>
+    <circle cx="1040" cy="450" r="14"/>
+    <circle cx="1280" cy="450" r="16"/>
+  </g>
+
+  <g fill="#7dd3fc" opacity="0.8">
+    <circle cx="440" cy="330" r="7"/>
+    <circle cx="680" cy="640" r="9"/>
+    <circle cx="920" cy="270" r="8"/>
+    <circle cx="1160" cy="620" r="7"/>
+    <circle cx="1360" cy="355" r="8"/>
+  </g>
+
+  <g stroke="#c4b5fd" stroke-width="3" stroke-linecap="round" opacity="0.72">
+    <path d="M320 450L440 330L560 450L680 640L800 450L920 270L1040 450L1160 620L1280 450L1360 355"/>
+  </g>
+
+  <g fill="#c4b5fd" opacity="0.9">
+    <rect x="250" y="210" width="44" height="44" rx="10"/>
+    <rect x="502" y="560" width="44" height="44" rx="10"/>
+    <rect x="755" y="210" width="44" height="44" rx="10"/>
+    <rect x="1008" y="560" width="44" height="44" rx="10"/>
+    <rect x="1260" y="210" width="44" height="44" rx="10"/>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Add a short, lowercase blog post that explores how abundant AGI shifts the bottleneck from planning to reliable physical execution using the "atoms + energy + instructions" framing.
- Preserve the concise, direct voice and short-paragraph/bullet style used in recent posts.

### Description
- Add a new post at `_posts/2026-02-25-post-agi-world-economy.md` containing the requested title, tags (`agi`, `economy`, `labor`, `execution`), and fully lowercase content. 
- The post outlines two AGI-driven shifts (coordination cost collapse vs. stubborn physical reality) and sketches a "superintelligent labor OS" model with bullet-point requirements for real-world task dispatch and verification.

### Testing
- Ran `bundle exec jekyll build` to validate the site build, but the `jekyll` executable was unavailable in the environment so the build failed. 
- Ran `bundle install` to install dependencies, but fetching gems failed with an HTTP 403 from `rubygems.org` so dependencies could not be installed. 
- Attempted a Playwright-driven screenshot of a local server (`http://localhost:4000`), but the request failed with `net::ERR_EMPTY_RESPONSE` because no local site server was available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f24060f98832ebee1c2fb97aab77a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new markdown content and a static SVG asset only, with no code or runtime behavior changes beyond rendering the new post and image.
> 
> **Overview**
> Adds a new blog post, `_posts/2026-02-25-post-agi-world-economy.md`, with tags and a fully lowercase essay about how abundant AGI shifts the bottleneck from planning to real-world execution (framed as *atoms + energy + instructions*).
> 
> Includes a new header image asset, `assets/img/post-agi-economy-header.svg`, referenced from the post.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bc3ac53b0cf80f10c0457471c09462a67c46202. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->