### PR TITLE
Add "something new" prefix to site profile description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ logo: assets/img/logo.png
 image: assets/img/logo.png
 github_username:  shyamal-anadkat
 linkedin_username: zostale
-description: ex-Applied AI @ OpenAI • AI Advisor to Startups • On Deck Fellow • Proud Son • Duke + Wisconsin Alum • Building for impact • Venture Scout • Neo Mentor • Duke AI Advisory Board
+description: something new • ex-Applied AI @ OpenAI • AI Advisor to Startups • On Deck Fellow • Proud Son • Duke + Wisconsin Alum • Building for impact • Venture Scout • Neo Mentor • Duke AI Advisory Board
 show_downloads: false
 google_analytics: G-38XE3DD209
 permalink: /blog/:title/


### PR DESCRIPTION
### Motivation
- Prepend `something new` to the site's profile description so the public-facing tagline is updated in ` _config.yml`.

### Description
- Updated the `description` entry in `_config.yml` by inserting `something new •` before `ex-Applied AI @ OpenAI`.

### Testing
- Verified the updated string with `rg -n "^description:" _config.yml` and attempted `bundle exec jekyll build`, which failed because the environment is missing the `jekyll` executable from Bundler.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f28b0b32c832ea153c51253ba6b05)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single string change in `_config.yml` affecting only the public-facing site metadata.
> 
> **Overview**
> Updates `_config.yml` to prepend **“something new •”** to the site `description`, changing the public-facing tagline/SEO metadata without altering any functionality.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6240c8189014beb4c46d66b730f4288b1adce5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->