### PR TITLE
Improve light mode readability with darker body text color

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -2,6 +2,7 @@
 
 body {
   font-family: 'Montserrat', sans-serif;
+  color: #060606;
 }
 
 h1, h2, h3, h4, h5, h6, p, a, span, div {


### PR DESCRIPTION
### Motivation
- Light-mode body text was too light and hard to read with the site's relatively small font size, so the default text color was adjusted to `#060606` for better contrast.

### Description
- Set `body { color: #060606; }` in `assets/css/theme.css` to increase text contrast in light mode while leaving existing dark-mode overrides unchanged.

### Testing
- Verified the CSS change with `git diff -- assets/css/theme.css`, served the site with `python3 -m http.server 4000`, and captured a visual check via a Playwright screenshot script; all automated steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3592436c832e856552704c2bce64)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS color tweak affecting default light-mode text rendering; minimal scope and no logic/security impact.
> 
> **Overview**
> Improves light-mode readability by setting a darker default `body` text color (`#060606`) in `assets/css/theme.css`.
> 
> Dark-mode styling remains unchanged because its existing overrides still set `body` text color for `prefers-color-scheme: dark` and `.dark-mode`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 053c7dc5fc94e8e822502fb8403161d26b6a531f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->