### PR TITLE
Improve blog SEO metadata, schema, and crawlability

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,7 @@
 layout: default
 title: "404: Page Not Found"
 permalink: /404.html
+sitemap: false
 ---
 
 <div class="not-found-container" style="text-align:center; margin: 5em auto; max-width: 600px;">

--- a/_config.yml
+++ b/_config.yml
@@ -17,3 +17,23 @@ description: something new • ex-Applied AI @ OpenAI • AI Advisor to Startups
 show_downloads: false
 google_analytics: G-38XE3DD209
 permalink: /blog/:title/
+
+social:
+  name: Shyamal Anadkat
+  links:
+    - https://github.com/shyamal-anadkat
+    - https://www.linkedin.com/in/zostale/
+
+defaults:
+  - scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: post
+      author: Shyamal Anadkat
+      image: /assets/img/logo.png
+  - scope:
+      path: ""
+      type: "pages"
+    values:
+      image: /assets/img/logo.png

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,12 @@
     <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{ '/feed.xml' | relative_url }}" />
 
     {% comment %} jekyll-seo-tag outputs standard SEO tags such as title and description {% endcomment %}
-    <meta name="robots" content="index, follow">
+    {% assign is_404 = page.permalink == '/404.html' or page.url == '/404.html' %}
+    {% if is_404 %}
+      <meta name="robots" content="noindex, follow">
+    {% else %}
+      <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+    {% endif %}
 
     {% seo %}
     {%- comment -%}
@@ -29,6 +34,30 @@
       <meta name="twitter:image" content="{{ share_image_url }}">
       <meta name="twitter:card" content="summary_large_image">
     {%- endif -%}
+    <meta name="twitter:site" content="@shyamalanadkat">
+
+    {% assign canonical_href = page.url | replace:'index.html','' | absolute_url %}
+    <link rel="canonical" href="{{ canonical_href }}">
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": {{ site.title | jsonify }},
+      "url": {{ site.url | jsonify }},
+      "description": {{ site.description | jsonify }},
+      "inLanguage": {{ site.lang | default: 'en-US' | jsonify }},
+      "publisher": {
+        "@type": "Person",
+        "name": {{ site.author | jsonify }}
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": {{ '/?q={search_term_string}' | absolute_url | jsonify }},
+        "query-input": "required name=search_term_string"
+      }
+    }
+    </script>
     <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
     <link rel="stylesheet" href="{{ "/assets/css/theme.css?v=" | append: site.github.build_revision | relative_url }}">
     <!--[if lt IE 9]>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -58,7 +58,7 @@ layout: default
       "@type": "ListItem",
       "position": 2,
       "name": "Blog",
-      "item": "{{ '/blog/' | absolute_url }}"
+      "item": "{{ '/' | absolute_url }}"
     },
     {
       "@type": "ListItem",
@@ -67,6 +67,32 @@ layout: default
       "item": "{{ page.url | absolute_url }}"
     }
   ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": {{ page.title | jsonify }},
+  "description": {{ page.excerpt | default: site.description | strip_html | normalize_whitespace | jsonify }},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "dateModified": "{{ page.last_modified_at | default: page.date | date_to_xmlschema }}",
+  "author": {
+    "@type": "Person",
+    "name": {{ page.author | default: site.author | jsonify }}
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": {{ site.author | jsonify }}
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ page.url | absolute_url }}"
+  },
+  "url": "{{ page.url | absolute_url }}",
+  "image": "{{ page.image | default: site.image | default: site.logo | absolute_url }}",
+  "keywords": {{ page.tags | join: ', ' | jsonify }}
 }
 </script>
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,7 @@
 ---
 layout: default
+title: Blog
+description: Essays on AI, startups, strategy, and the future of work by Shyamal Anadkat.
 ---
 
 <div class="home-animate">

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,5 @@
 User-agent: *
 Allow: /
+
 Sitemap: https://shyamal.me/sitemap.xml
+Host: shyamal.me

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,30 +1,29 @@
 ---
-layout: 
+layout: null
+permalink: /sitemap.xml
 ---
-
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  {% for page in site.pages %}
-  {% if page.url contains '.xml' or page.url contains 'assets' %}{% else %}
-      <url>
-        <loc>{{ site.url }}{{ page.url }}</loc>
-        <changefreq>monthly</changefreq>
-        <priority>1.0</priority>
-       </url>
-  {% endif %}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% assign pages_for_sitemap = site.pages | where_exp: 'item', "item.sitemap != false" %}
+  {% for page in pages_for_sitemap %}
+    {% assign is_html = page.url contains '.html' %}
+    {% assign is_xml = page.url contains '.xml' %}
+    {% assign is_asset = page.url contains '/assets/' %}
+    {% if is_xml or is_asset %}{% continue %}{% endif %}
+    <url>
+      <loc>{{ page.url | replace:'index.html','' | absolute_url }}</loc>
+      <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+      <changefreq>{% if page.url == '/' %}weekly{% else %}monthly{% endif %}</changefreq>
+      <priority>{% if page.url == '/' %}1.0{% else %}0.7{% endif %}</priority>
+    </url>
   {% endfor %}
-  {% for page in site.posts %}
-      <url>
-        <loc>{{ site.url }}{{ page.url | replace: 'index.html', '' }}</loc>
-        <changefreq>monthly</changefreq>
-        <priority>1.0</priority>
-       </url>
-  {% endfor %}
-  {% for page in site.without-plugin %}
-      <url>
-        <loc>{{ site.url }}{{ page.url | replace: 'index.html', '' }}</loc>
-        <changefreq>monthly</changefreq>
-        <priority>1.0</priority>
-       </url>
+
+  {% for post in site.posts %}
+    <url>
+      <loc>{{ post.url | replace:'index.html','' | absolute_url }}</loc>
+      <lastmod>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</lastmod>
+      <changefreq>monthly</changefreq>
+      <priority>0.9</priority>
+    </url>
   {% endfor %}
 </urlset>

--- a/subscribe.html
+++ b/subscribe.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Subscribe
+description: Subscribe via RSS/Atom feed to get new essays as they are published.
 permalink: /subscribe/
 ---
 

--- a/tags/index.html
+++ b/tags/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Tags
+description: Browse posts by topic and tag.
 permalink: /tags/
 ---
 


### PR DESCRIPTION
### Motivation

- Reduce indexing noise and improve search/social previews by adding consistent metadata, canonicalization, and structured data across pages and posts.  
- Improve crawlability and sitemap quality so search engines pick up fresh content and ignore irrelevant pages (404s, assets).  
- Provide sensible defaults for posts/pages so authors don't need to duplicate image/author metadata in every front matter.  

### Description

- Added social profile links and global defaults to `_config.yml` so posts/pages inherit `author`, `image`, and `layout` values.  
- Enhanced the global head (`_layouts/default.html`) with conditional `robots` (noindex for 404), explicit `canonical` link, `twitter:site`, and a `WebSite` JSON-LD block including a `SearchAction`.  
- Enriched post pages (`_layouts/post.html`) by fixing the breadcrumb `item` URL and adding `BlogPosting` JSON-LD including `headline`, `description`, `datePublished`, `dateModified`, `author`, `publisher`, `image`, and `keywords`.  
- Reworked `sitemap.xml` to skip assets/XML pages, include `lastmod`, and set differentiated `priority`/`changefreq` for the home, pages, and posts; added `sitemap: false` front matter for the 404 page and updated `robots.txt` with `Sitemap` and `Host`.  
- Added page-level `title` and `description` front matter to key landing pages (`index.html`, `tags/index.html`, `subscribe.html`) to improve SERP snippets.  

### Testing

- Attempted a site build with `bundle exec jekyll build`, which could not run because the `jekyll` executable was not available in this environment (tooling missing).  
- Attempted dependency installation with `bundle install`, which failed due to external Rubygems fetch errors (HTTP 403) in this environment, so automated build validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f354ad060832e88b7cd8f719128c4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static-site SEO and sitemap changes only; primary risk is incorrect canonical/robots/sitemap output affecting indexing rather than runtime behavior.
> 
> **Overview**
> Improves SEO metadata and canonicalization across the site by updating the global head to emit conditional `robots` (noindex for 404), a canonical URL, `twitter:site`, and `WebSite` JSON-LD (with `SearchAction`) alongside consistent social share images.
> 
> Enhances post-level structured data by fixing breadcrumb URLs and adding `BlogPosting` JSON-LD (headline/description/dates/author/publisher/image/keywords), and adds global `_config.yml` defaults (author/layout/image) plus `social.links` to reduce per-page front matter.
> 
> Cleans up crawl directives and indexing noise by excluding the 404 page from the sitemap, rewriting `sitemap.xml` to skip assets/XML and include `lastmod`/priority/changefreq, adding `Sitemap`/`Host` to `robots.txt`, and providing titles/descriptions for key pages (`index`, `tags`, `subscribe`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b92abb8faae60cd8440da2b60267af2143201a33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->