### PR TITLE
Fix Liquid syntax error in SearchAction JSON-LD target

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,7 @@
       },
       "potentialAction": {
         "@type": "SearchAction",
-        "target": {{ '/?q={search_term_string}' | absolute_url | jsonify }},
+        "target": {{ '/?q=SEARCH_TERM' | absolute_url | replace: 'SEARCH_TERM', '{search_term_string}' | jsonify }},
         "query-input": "required name=search_term_string"
       }
     }


### PR DESCRIPTION
### Motivation
- Resolve a Jekyll/Liquid parse error caused by embedding `{search_term_string}` directly inside a Liquid string in the JSON-LD `SearchAction`, which produced a "Variable ... was not properly terminated" error during site builds.

### Description
- In `/_layouts/default.html` the `SearchAction.target` expression was changed from `{{ '/?q={search_term_string}' | absolute_url | jsonify }}` to `{{ '/?q=SEARCH_TERM' | absolute_url | replace: 'SEARCH_TERM', '{search_term_string}' | jsonify }}` so the placeholder braces are not misinterpreted by Liquid.

### Testing
- Ran `bundle exec jekyll build` to validate the change, but the local environment is missing the `jekyll` executable so the build could not be completed (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3aa75820832e87b8107347dfb8f6)