### PR TITLE
Fix JSON-LD SearchAction target formatting in default layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -53,7 +53,7 @@
       },
       "potentialAction": {
         "@type": "SearchAction",
-        "target": {{ '/?q={search_term_string}' | absolute_url | jsonify }},
+        "target": "{{ '/?q=' | absolute_url }}{search_term_string}",
         "query-input": "required name=search_term_string"
       }
     }


### PR DESCRIPTION
### Motivation

- Ensure the `SearchAction` `target` in the page JSON-LD contains a usable search URL template rather than a JSON-escaped or malformed value.

### Description

- Replace the Liquid expression that used `jsonify` on the search URL with a string that concatenates the absolute base search URL and the `{search_term_string}` placeholder: change from `{{ '/?q={search_term_string}' | absolute_url | jsonify }}` to `"{{ '/?q=' | absolute_url }}{search_term_string}"` in `_layouts/default.html`.

### Testing

- Ran `jekyll build` and the site built successfully with the generated JSON-LD `target` containing the expected URL template.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f3aa75820832e87b8107347dfb8f6)