### PR TITLE
Add MentorCruise embed badge to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@ description: Essays on AI, startups, strategy, and the future of work by Shyamal
 <div class="home-animate">
 <i>Opinions expressed are solely my own and do not express the views or opinions of my employer</i></br></br>
 
+<a href="https://mentorcruise.com/mentor/shyamalanadkat/?source=embed">
+  <img src="https://cdn.mentorcruise.com/img/banner/navy-booking-badge.svg" width="180" alt="MentorCruise">
+</a>
+
+<br><br>
+
 <div class="featured-posts">
   <h2>Featured Posts</h2>
   


### PR DESCRIPTION
### Motivation
- Make it easy for visitors to start a chat or book a mentoring session directly from the blog homepage. 
- Surface the MentorCruise booking badge prominently above the featured posts so it’s visible on page load.

### Description
- Inserted a MentorCruise anchor and badge image near the top of the homepage content in `index.html`.
- Added small vertical spacing (`<br><br>`) after the embed so it sits cleanly before the featured posts section.

### Testing
- Served the site locally with `python3 -m http.server 8000 --bind 0.0.0.0` and verified the page served successfully. 
- Captured a browser screenshot via a Playwright script to confirm the badge renders on the page (screenshot artifact generated). 
- Attempted `bundle exec jekyll serve` which failed in this environment because the `jekyll`/Bundler executables are not installed (installation is required to run this command here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a935cd8408832e83df7ca8d43bfc74)