### PR TITLE
Add MentorCruise embed to header and responsive styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -101,6 +101,12 @@
           <a href="{{ '/subscribe/' | relative_url }}">Subscribe</a>
         </nav>
 
+        <div class="mentorcruise-embed" style="margin-top:1rem;">
+          <a href="https://mentorcruise.com/mentor/shyamalanadkat/?source=embed">
+            <img src="https://cdn.mentorcruise.com/img/banner/navy-booking-badge.svg" width="180" alt="MentorCruise">
+          </a>
+        </div>
+
         <div class="theme-control" style="margin-top:1rem;">
           <p class="theme-label">Dark Mode</p>
           <div class="theme-toggle">

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -187,6 +187,16 @@ body.dark-mode em, body.dark-mode i {
   margin-bottom: 1rem;
 }
 
+.mentorcruise-embed {
+  margin-bottom: 1rem;
+}
+
+.mentorcruise-embed img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
 .theme-label {
   font-size: 14px;
   font-weight: 600;


### PR DESCRIPTION
### Motivation

- Add a MentorCruise booking badge to the site header to surface mentoring availability and drive referrals.
- Ensure the embed is visually consistent and responsive within the existing header layout.

### Description

- Inserted a `div` with class `mentorcruise-embed` containing an anchor and image pointing to the MentorCruise profile in `_layouts/default.html`.
- Added CSS rules in `assets/css/theme.css` for `.mentorcruise-embed` and `.mentorcruise-embed img` to provide spacing and responsive sizing.
- Left existing theme toggle and search markup intact and placed the embed above the theme control for prominence.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a935cd8408832e83df7ca8d43bfc74)