### PR TITLE
Add MentorCruise embed banner to site header and styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -101,6 +101,12 @@
           <a href="{{ '/subscribe/' | relative_url }}">Subscribe</a>
         </nav>
 
+        <div class="mentorcruise-embed" style="margin-top:1rem;">
+          <a href="https://mentorcruise.com/mentor/shyamalanadkat/?source=embed">
+            <img src="https://cdn.mentorcruise.com/img/banner/navy-sm.svg" width="180" alt="MentorCruise">
+          </a>
+        </div>
+
         <div class="theme-control" style="margin-top:1rem;">
           <p class="theme-label">Dark Mode</p>
           <div class="theme-toggle">

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -187,6 +187,16 @@ body.dark-mode em, body.dark-mode i {
   margin-bottom: 1rem;
 }
 
+.mentorcruise-embed {
+  margin-bottom: 1rem;
+}
+
+.mentorcruise-embed img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
 .theme-label {
   font-size: 14px;
   font-weight: 600;


### PR DESCRIPTION
### Motivation
- Surface a MentorCruise sponsorship/mentor link in the site header to increase visibility and provide a direct call-to-action for mentoring services.

### Description
- Inserted a MentorCruise embed block into the header in `_layouts/default.html` containing a linked banner image with a small top margin.
- Added CSS rules in `assets/css/theme.css` for `.mentorcruise-embed` and its `img` to ensure responsive sizing and spacing alongside the existing theme controls.
- Kept the theme toggle and search markup intact and placed the embed above the theme control for prominence.

### Testing
- Ran a site build with `bundle exec jekyll build` and the build completed successfully.
- Performed a local visual check by serving the site (`bundle exec jekyll serve`) to confirm the banner renders and the layout/styles behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a935cd8408832e83df7ca8d43bfc74)