### PR TITLE
Improve indexing signals for parameterized URLs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -50,11 +50,6 @@
       "publisher": {
         "@type": "Person",
         "name": {{ site.author | jsonify }}
-      },
-      "potentialAction": {
-        "@type": "SearchAction",
-        "target": "{{ '/?q=' | absolute_url }}{search_term_string}",
-        "query-input": "required name=search_term_string"
       }
     }
     </script>

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Disallow: /*?*
 
 Sitemap: https://shyamal.me/sitemap.xml
 Host: shyamal.me


### PR DESCRIPTION
### Motivation
- Reduce indexing noise caused by query-parameter variants (for example `?ref=` and `?utm_*`) that appear in Search Console as alternate/duplicate pages.
- Prevent exposing a synthetic site search URL pattern in structured data that can surface `/?q={search_term_string}` to search engines.

### Description
- Removed the `SearchAction` object from the site-wide JSON-LD `WebSite` schema in `_layouts/default.html`, eliminating the advertised `/?q={search_term_string}` pattern.
- Added `Disallow: /*?*` to `robots.txt` to discourage crawling of any URLs that contain query strings while leaving canonical paths crawlable.
- Kept the existing canonical link logic intact (`<link rel="canonical">`) so clean URLs remain the canonical targets.

### Testing
- Verified the template changes by inspecting `/_layouts/default.html` and `robots.txt` and confirming the `SearchAction` removal and `Disallow: /*?*` addition.
- Ran `git diff`/file inspections to confirm the two-file change set applied as intended.
- Attempted a local site build with `bundle exec jekyll build` and `bundle install`, but those steps failed due to the environment's Rubygems/Bundler network errors (HTTP 403) so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0e50292c832e90a23acf42884bcf)