### PR TITLE
Remove duplicate canonical tag to reduce indexing conflicts

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,9 +36,6 @@
     {%- endif -%}
     <meta name="twitter:site" content="@shyamalanadkat">
 
-    {% assign canonical_href = page.url | replace:'index.html','' | absolute_url %}
-    <link rel="canonical" href="{{ canonical_href }}">
-
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",


### PR DESCRIPTION
### Motivation
- Search engines were receiving conflicting canonical signals because the layout both included a manually-injected `<link rel="canonical">` and used `{% seo %}` from `jekyll-seo-tag`, which can cause pages to be reported as “Alternate page with proper canonical tag.”

### Description
- Removed the manually-generated canonical link from `_layouts/default.html` so the site relies on the canonical output from `{% seo %}` only. 
- No other layout or content changes were made.

### Testing
- Confirmed the manual canonical block is absent by inspecting `_layouts/default.html` with `nl -ba` and via `git diff`, which showed the three-line removal, and those checks succeeded. 
- Attempted a local Jekyll build with `bundle exec jekyll build`, but dependency installation failed in this environment due to Rubygems/Bundler `403 Forbidden` errors, so a full site build could not be completed here. 
- Verified that the change is limited to the layout and does not introduce template syntax errors by a quick template inspection, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b84dd45d50832e961508fab7c37bfe)